### PR TITLE
Feature/culture scope

### DIFF
--- a/src/Spk.Common.Helpers/Localization/CultureScope.cs
+++ b/src/Spk.Common.Helpers/Localization/CultureScope.cs
@@ -25,14 +25,13 @@ namespace Spk.Common.Helpers.Localization
             Apply(mode, new CultureInfo(cultureName));
         }
 
-
         private static void Apply(CultureScopeMode mode, CultureInfo culture)
         {
             if (mode.HasFlag(CultureScopeMode.Main))
             {
 #if NETSTANDARD2_0
                 CultureInfo.CurrentCulture = culture;
-#elif NET45
+#elif NET452
                 Thread.CurrentThread.CurrentCulture = culture;
 #endif
             }
@@ -40,7 +39,7 @@ namespace Spk.Common.Helpers.Localization
             {
 #if NETSTANDARD2_0
                 CultureInfo.CurrentUICulture = culture;
-#elif NET45
+#elif NET452
                 Thread.CurrentThread.CurrentUICulture = culture;
 #endif
             }
@@ -51,7 +50,7 @@ namespace Spk.Common.Helpers.Localization
 #if NETSTANDARD2_0
             CultureInfo.CurrentCulture = _initialMain;
             CultureInfo.CurrentUICulture = _initialUi;
-#elif NET45
+#elif NET452
             Thread.CurrentThread.CurrentCulture = _initialMain;
             Thread.CurrentThread.CurrentUICulture = _initialUi;
 #endif

--- a/src/Spk.Common.Helpers/Localization/CultureScope.cs
+++ b/src/Spk.Common.Helpers/Localization/CultureScope.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace Spk.Common.Helpers.Localization
+{
+    public class CultureScope : IDisposable
+    {
+        private readonly CultureInfo _initialMain;
+        private readonly CultureInfo _initialUi;
+
+        public CultureScope()
+        {
+            _initialMain = CultureInfo.CurrentCulture;
+            _initialUi = CultureInfo.CurrentUICulture;
+        }
+        
+        public CultureScope(CultureInfo culture, CultureScopeMode mode = CultureScopeMode.Both) : this()
+        {
+            Apply(mode, culture);
+        }
+
+        public CultureScope(string cultureName, CultureScopeMode mode = CultureScopeMode.Both) : this()
+        {
+            Apply(mode, new CultureInfo(cultureName));
+        }
+
+
+        private static void Apply(CultureScopeMode mode, CultureInfo culture)
+        {
+            if (mode.HasFlag(CultureScopeMode.Main))
+            {
+#if NETSTANDARD2_0
+                CultureInfo.CurrentCulture = culture;
+#elif NET45
+                Thread.CurrentThread.CurrentCulture = culture;
+#endif
+            }
+            if (mode.HasFlag(CultureScopeMode.Ui))
+            {
+#if NETSTANDARD2_0
+                CultureInfo.CurrentUICulture = culture;
+#elif NET45
+                Thread.CurrentThread.CurrentUICulture = culture;
+#endif
+            }
+        }
+
+        public void Dispose()
+        {
+#if NETSTANDARD2_0
+            CultureInfo.CurrentCulture = _initialMain;
+            CultureInfo.CurrentUICulture = _initialUi;
+#elif NET45
+            Thread.CurrentThread.CurrentCulture = _initialMain;
+            Thread.CurrentThread.CurrentUICulture = _initialUi;
+#endif
+        }
+    }
+
+    [Flags]
+    public enum CultureScopeMode
+    {
+        Main = 1,
+        Ui = 2,
+        Both = 3
+    }
+}

--- a/src/Spk.Common.Helpers/Localization/CultureScope.cs
+++ b/src/Spk.Common.Helpers/Localization/CultureScope.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Threading;
+using Spk.Common.Helpers.Guard;
 
 namespace Spk.Common.Helpers.Localization
 {
@@ -27,6 +28,8 @@ namespace Spk.Common.Helpers.Localization
 
         private static void Apply(CultureScopeMode mode, CultureInfo culture)
         {
+            culture.GuardIsNotNull(nameof(culture));
+
             if (mode.HasFlag(CultureScopeMode.Main))
             {
 #if NETSTANDARD2_0

--- a/test/Spk.Common.Tests.Helpers/Localization/CultureScopeTests.cs
+++ b/test/Spk.Common.Tests.Helpers/Localization/CultureScopeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Threading;
 using Shouldly;
@@ -70,6 +71,13 @@ namespace Spk.Common.Tests.Helpers.Localization
 
             CultureInfo.CurrentCulture.Name.ShouldBe(Initial);
             CultureInfo.CurrentUICulture.Name.ShouldBe(Initial);
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_WhenCultureInfoIsNull()
+        {
+            CultureInfo nullCulture = null;
+            Assert.Throws<ArgumentNullException>(() => new CultureScope(nullCulture));
         }
     }
 }

--- a/test/Spk.Common.Tests.Helpers/Localization/CultureScopeTests.cs
+++ b/test/Spk.Common.Tests.Helpers/Localization/CultureScopeTests.cs
@@ -1,0 +1,75 @@
+using System.Globalization;
+using System.Threading;
+using Shouldly;
+using Spk.Common.Helpers.Localization;
+using Xunit;
+
+namespace Spk.Common.Tests.Helpers.Localization
+{
+    public class CultureScopeTests
+    {
+        private const string Initial = "fr-CA";
+
+        public CultureScopeTests()
+        {
+            var cultureInfo = CultureInfo.CreateSpecificCulture(Initial);
+
+#if NET452
+            Thread.CurrentThread.CurrentUICulture = cultureInfo;
+            Thread.CurrentThread.CurrentCulture = cultureInfo;
+#endif
+
+#if NETCOREAPP2_0
+            CultureInfo.CurrentCulture = cultureInfo;
+            CultureInfo.CurrentUICulture = cultureInfo;
+#endif
+        }
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("en-GB")]
+        public void Should_EditBothCulturesOfCurrentThread_WhenModeIsBoth(string modified)
+        {
+            using (new CultureScope(modified, CultureScopeMode.Both))
+            {
+                CultureInfo.CurrentCulture.Name.ShouldBe(modified);
+                CultureInfo.CurrentUICulture.Name.ShouldBe(modified);
+            }
+        }
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("en-GB")]
+        public void Should_EditMainCulturesOfCurrentThread_WhenModeIsMain(string modified)
+        {
+            using (new CultureScope(modified, CultureScopeMode.Main))
+            {
+                CultureInfo.CurrentCulture.Name.ShouldBe(modified);
+                CultureInfo.CurrentUICulture.Name.ShouldBe(Initial);
+            }
+        }
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("en-GB")]
+        public void Should_EditUiCulturesOfCurrentThread_WhenModeIsUi(string modified)
+        {
+            using (new CultureScope(modified, CultureScopeMode.Ui))
+            {
+                CultureInfo.CurrentCulture.Name.ShouldBe(Initial);
+                CultureInfo.CurrentUICulture.Name.ShouldBe(modified);
+            }
+        }
+
+        [Fact]
+        public void Should_RestoreCulture_WhenDisposed()
+        {
+            using (new CultureScope("en-US", CultureScopeMode.Ui))
+            {
+            }
+
+            CultureInfo.CurrentCulture.Name.ShouldBe(Initial);
+            CultureInfo.CurrentUICulture.Name.ShouldBe(Initial);
+        }
+    }
+}


### PR DESCRIPTION
This is a handy culture scoping utility that alters current thread culture until you dispose it. Usefull, for example, to send emails to users in their own language.