### PR TITLE
IEnumerable extension: ParallelForEach

### DIFF
--- a/src/Spk.Common.Helpers/IEnumerable/ParallelForEachExtension.cs
+++ b/src/Spk.Common.Helpers/IEnumerable/ParallelForEachExtension.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Spk.Common.Helpers.Guard;
+
+namespace Spk.Common.Helpers.IEnumerable
+{
+    public static class ParallelForEachExtension
+    {
+        /// <summary>
+        ///     Execute a function for every item inside an IEnumerable.
+        ///     Functions are executed in parallel for performance purposes.
+        ///     The function returns when all tasks are done.
+        /// </summary>
+        /// <typeparam name="T">Type of the items in the collections</typeparam>
+        /// <param name="source">The source elements</param>
+        /// <param name="task">Delegate function to execute</param>
+        public static void ParallelForEach<T>(
+            this IEnumerable<T> source,
+            Func<T, Task> task,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            source.GuardIsNotNull(nameof(source));
+            task.GuardIsNotNull(nameof(task));
+            Task.WaitAll(
+                source.Select(x => task(x)).ToArray(),
+                cancellationToken
+            );
+        }
+    }
+}

--- a/test/Spk.Common.Tests.Helpers/IEnumerable/ParallelForEachExtensionTests.cs
+++ b/test/Spk.Common.Tests.Helpers/IEnumerable/ParallelForEachExtensionTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Shouldly;
+using Spk.Common.Helpers.IEnumerable;
+using Xunit;
+
+namespace Spk.Common.Tests.Helpers.IEnumerable
+{
+    public class ParallelForEachExtensionTests
+    {
+        [Theory]
+        [InlineData(1000, 50)]
+        public void ParallelForEach_ShouldExecuteTasks_AtOnce(int ms, int numberOfTask)
+        {
+            // Arrange
+            var stopWatch = new Stopwatch();
+
+            // Act
+            stopWatch.Start();
+            new object[numberOfTask].ParallelForEach(async x => await Task.Delay(ms));
+            stopWatch.Stop();
+
+            // Assert
+            ((int)stopWatch.ElapsedMilliseconds).ShouldBeLessThan(numberOfTask * ms);
+        }
+
+        [Fact]
+        public void ParallelForEach_ShouldThrows_WhenCancellationTokenCancelTriggered()
+        {
+            // Arrange
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            // Act & assert
+            Task.Run(() =>
+                Assert.Throws<OperationCanceledException>(() =>
+                    new object[50].ParallelForEach(async x => await Task.Delay(5000),
+                        cancellationTokenSource.Token))
+            );
+            cancellationTokenSource.Cancel();
+        }
+
+        [Fact]
+        public void ParallelForEach_ShouldThrows_WhenSourceIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => { ((List<string>)null).ParallelForEach(s => null); });
+        }
+
+        [Fact]
+        public void ParallelForEach_ShouldThrows_WhenTaskIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => { new List<string>().ParallelForEach(null); });
+        }
+    }
+}


### PR DESCRIPTION
Very useful for long-running tasks that can be parallelized. A possible use-case: multiple HTTP requests.

