### PR TITLE
Feature/string safe format

### DIFF
--- a/src/Spk.Common.Helpers/String/StringExtensions.cs
+++ b/src/Spk.Common.Helpers/String/StringExtensions.cs
@@ -178,7 +178,7 @@ namespace Spk.Common.Helpers.String
 
                 var value = (propertyGroup.Value == "0")
                     ? data
-                    : data.GetType().GetProperty(propertyGroup.Value)?.GetValue(data);
+                    : data?.GetType().GetProperty(propertyGroup.Value)?.GetValue(data);
 
                 if (value != null)
                 {

--- a/test/Spk.Common.Tests.Helpers/String/StringExtensionsTests.cs
+++ b/test/Spk.Common.Tests.Helpers/String/StringExtensionsTests.cs
@@ -144,6 +144,34 @@ namespace Spk.Common.Tests.Helpers.String
         }
 
         [Fact]
+        public void FormatWith_ShouldFormat_WithNullData()
+        {
+            var stringToFormat = "My name is {firstName} {lastName}, I am {age} years old.";
+            var data = new
+            {
+                firstName = (string) null,
+                lastName = "LN",
+                age = 28
+            };
+
+            Assert.Equal("My name is  LN, I am 28 years old.", stringToFormat.FormatWith(data));
+        }
+
+        [Fact]
+        public void FormatWith_ShouldFormat_WithDoubleData()
+        {
+            var stringToFormat = "My name is {firstName} {lastName}, I am {age} years old. {age}";
+            var data = new
+            {
+                firstName = "François",
+                lastName = "LN",
+                age = 28
+            };
+
+            Assert.Equal("My name is François LN, I am 28 years old. 28", stringToFormat.FormatWith(data));
+        }
+
+        [Fact]
         public void FormatWith_ShouldFormat_WhenExtraDataMarkerInString()
         {
             var stringToFormat = "My name is {firstName} {lastName}, I am {age} years old.";
@@ -187,10 +215,19 @@ namespace Spk.Common.Tests.Helpers.String
         [Fact]
         public void FormatWith_ShouldFormat_WithNoData()
         {
-            var stringToFormat = "My name real name is Olivier.";
+            var stringToFormat = "My name real name is Olivier {var}.";
             var data = new {};
 
-            Assert.Equal("My name real name is Olivier.", stringToFormat.FormatWith(data));
+            Assert.Equal("My name real name is Olivier .", stringToFormat.FormatWith(data));
+        }
+
+        [Fact]
+        public void FormatWith_ShouldFormat_WithNull()
+        {
+            var stringToFormat = "My name real name is Olivier {var}.";
+            object data = null;
+
+            Assert.Equal("My name real name is Olivier .", stringToFormat.FormatWith(data));
         }
     }
 }

--- a/test/Spk.Common.Tests.Helpers/String/StringExtensionsTests.cs
+++ b/test/Spk.Common.Tests.Helpers/String/StringExtensionsTests.cs
@@ -128,5 +128,69 @@ namespace Spk.Common.Tests.Helpers.String
             var splitByCharResult = stringToSplit.Split(separator);
             splitByStringResult.ShouldBe(splitByCharResult);
         }
+
+        [Fact]
+        public void FormatWith_ShouldFormat_WhenPerfectMatchWithData()
+        {
+            var stringToFormat = "My name is {firstName} {lastName}, I am {age} years old.";
+            var data = new
+            {
+                firstName = "François",
+                lastName = "LN",
+                age = 28
+            };
+
+            Assert.Equal("My name is François LN, I am 28 years old.", stringToFormat.FormatWith(data));
+        }
+
+        [Fact]
+        public void FormatWith_ShouldFormat_WhenExtraDataMarkerInString()
+        {
+            var stringToFormat = "My name is {firstName} {lastName}, I am {age} years old.";
+            var data = new
+            {
+                firstName = "François",
+                lastName = "LN",
+            };
+
+            Assert.Equal("My name is François LN, I am  years old.", stringToFormat.FormatWith(data));
+        }
+
+        [Fact]
+        public void FormatWith_ShouldFormat_WhenExtraDataInObject()
+        {
+            var stringToFormat = "My name is {firstName} {lastName}.";
+            var data = new
+            {
+                firstName = "François",
+                lastName = "LN",
+                age = 28
+            };
+
+            Assert.Equal("My name is François LN.", stringToFormat.FormatWith(data));
+        }
+
+        [Fact]
+        public void FormatWith_ShouldFormat_WithEmptyString()
+        {
+            var stringToFormat = "";
+            var data = new
+            {
+                firstName = "François",
+                lastName = "LN",
+                age = 28
+            };
+
+            Assert.Equal("", stringToFormat.FormatWith(data));
+        }
+
+        [Fact]
+        public void FormatWith_ShouldFormat_WithNoData()
+        {
+            var stringToFormat = "My name real name is Olivier.";
+            var data = new {};
+
+            Assert.Equal("My name real name is Olivier.", stringToFormat.FormatWith(data));
+        }
     }
 }


### PR DESCRIPTION
Pour éviter que ça plante si il y a un {tag} dans la string qui n'est pas dans l'objet de format. 
Permet de safely format une string du genre : 

> Bonjour {firstName}, bye. 