### PR TITLE
RemoveWhere extension method refactor.

### DIFF
--- a/src/Spk.Common.Helpers/Collection/RemoveWhereExtension.cs
+++ b/src/Spk.Common.Helpers/Collection/RemoveWhereExtension.cs
@@ -16,14 +16,23 @@ namespace Spk.Common.Helpers.Collection
             if (!source.Any())
                 return source;
 
-            var elements = source.Where(predicate).ToList();
-            foreach (var element in elements)
+            if (source is IList<TSource> list)
             {
-                source.Remove(element);
+                for (int i = list.Count - 1; i >= 0; i--)
+                {
+                    if (predicate(list[i]))
+                    {
+                        list.RemoveAt(i);
+                    }
+                }
+
+                return list;
             }
 
+            source.Where(predicate)
+                .ToList()
+                .ForEach(x => source.Remove(x));
             return source;
         }
     }
-
 }

--- a/test/Spk.Common.Benchmarks/Helpers/Collection/OldRemoveWhereExtension.cs
+++ b/test/Spk.Common.Benchmarks/Helpers/Collection/OldRemoveWhereExtension.cs
@@ -1,27 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Spk.Common.Helpers.Guard;
 
 namespace Spk.Common.Benchmarks.Helpers.Collection
 {
     public static class RemoveWhereExtension
     {
-        public static ICollection<TSource> RemoveWhereTest<TSource>(
+        public static ICollection<TSource> RemoveWhereOld<TSource>(
             this ICollection<TSource> source,
             Func<TSource, bool> predicate)
         {
             source.GuardIsNotNull(nameof(source));
 
             if (!source.Any())
+            {
                 return source;
+            }
 
             var elements = source.Where(predicate).ToList();
             foreach (var element in elements)
-            {
                 source.Remove(element);
-            }
 
             return source;
         }

--- a/test/Spk.Common.Benchmarks/Helpers/Collection/OldRemoveWhereExtension.cs
+++ b/test/Spk.Common.Benchmarks/Helpers/Collection/OldRemoveWhereExtension.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Spk.Common.Helpers.Guard;
+
+namespace Spk.Common.Benchmarks.Helpers.Collection
+{
+    public static class RemoveWhereExtension
+    {
+        public static ICollection<TSource> RemoveWhereTest<TSource>(
+            this ICollection<TSource> source,
+            Func<TSource, bool> predicate)
+        {
+            source.GuardIsNotNull(nameof(source));
+
+            if (!source.Any())
+                return source;
+
+            var elements = source.Where(predicate).ToList();
+            foreach (var element in elements)
+            {
+                source.Remove(element);
+            }
+
+            return source;
+        }
+    }
+}

--- a/test/Spk.Common.Benchmarks/Helpers/Collection/RemoveWhereExtensionBenchmarks.cs
+++ b/test/Spk.Common.Benchmarks/Helpers/Collection/RemoveWhereExtensionBenchmarks.cs
@@ -26,7 +26,7 @@ namespace Spk.Common.Benchmarks.Helpers.Collection
         [Benchmark]
         public ICollection<string> RemoveWhere_Initial()
         {
-            return _source.RemoveWhereTest(x => x.Contains("1"));
+            return _source.RemoveWhereOld(x => x.Contains("1"));
         }
     }
 }

--- a/test/Spk.Common.Benchmarks/Helpers/Collection/RemoveWhereExtensionBenchmarks.cs
+++ b/test/Spk.Common.Benchmarks/Helpers/Collection/RemoveWhereExtensionBenchmarks.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Spk.Common.Helpers.Collection;
+
+namespace Spk.Common.Benchmarks.Helpers.Collection
+{
+    [MemoryDiagnoser]
+    public class RemoveWhereExtensionBenchmarks
+    {
+        private List<string> _source;
+
+        [GlobalSetup]
+        public void InitialData()
+        {
+            _source = new List<string>();
+            for (int i = 0; i < 5000; i++)
+                _source.Add("value" + i);
+        }
+
+        [Benchmark]
+        public ICollection<string> RemoveWhere_Optimized()
+        {
+            return _source.RemoveWhere(x => x.Contains("1"));
+        }
+
+        [Benchmark]
+        public ICollection<string> RemoveWhere_Initial()
+        {
+            return _source.RemoveWhereTest(x => x.Contains("1"));
+        }
+    }
+}

--- a/test/Spk.Common.Benchmarks/Program.cs
+++ b/test/Spk.Common.Benchmarks/Program.cs
@@ -1,13 +1,13 @@
 using BenchmarkDotNet.Running;
-using Spk.Common.Benchmarks.Helpers.IEnumerable;
+using Spk.Common.Benchmarks.Helpers.Collection;
 
 namespace Spk.Common.Benchmarks
 {
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
-            BenchmarkRunner.Run<ShuffleExtensionBenchmarks>();
+            BenchmarkRunner.Run<RemoveWhereExtensionBenchmarks>();
         }
     }
 }

--- a/test/Spk.Common.Tests.Helpers/Collections/RemoveWhereExtensionTests.cs
+++ b/test/Spk.Common.Tests.Helpers/Collections/RemoveWhereExtensionTests.cs
@@ -7,66 +7,11 @@ namespace Spk.Common.Tests.Helpers.Collections
 {
     public class RemoveWhereExtensionTests
     {
-        [Fact]
-        public void RemoveWhere_ShouldNotRemoveAnyItems_WhenPredicateIsFalse()
+        private readonly List<string> _data;
+
+        public RemoveWhereExtensionTests()
         {
-            var data = new List<string>
-            {
-                "pomme",
-                "fraise",
-                "raisin",
-                "banane"
-            };
-
-            var result = data.RemoveWhere(x => x == "orange");
-
-            Assert.Equal(data.Count, result.Count);
-            Assert.DoesNotContain("orange", data);
-        }
-
-        [Fact]
-        public void RemoveWhere_ShouldRemoveAllElementsThatMatchesThePredicate()
-        {
-            var data = new List<string>
-            {
-                "pomme",
-                "fraise",
-                "raisin",
-                "banane"
-            };
-
-            var result = data.RemoveWhere(x => x == "fraise" || x == "banane");
-
-            Assert.Equal(2, result.Count);
-            Assert.DoesNotContain("fraise", data);
-            Assert.DoesNotContain("banane", data);
-        }
-
-        [Fact]
-        public void RemoveWhere_ShouldRemoveOneElement_WhenPredicateMatchesOneElement()
-        {
-            var data = new List<string>
-            {
-                "pomme",
-                "fraise",
-                "raisin",
-                "banane"
-            };
-
-            var result = data.RemoveWhere(x => x == "fraise");
-
-            Assert.Equal(3, result.Count);
-            Assert.DoesNotContain("fraise", data);
-        }
-
-        [Fact]
-        public void RemoveWhere_ShouldReturn_WhenSourceIsEmpty()
-        {
-            var data = new List<string>();
-
-            var result = data.RemoveWhere(x => x == "fraise" || x == "banane");
-
-            Assert.Equal(0, result.Count);
+            _data = new List<string> {"pomme", "fraise", "raisin", "banane"};
         }
 
         [Fact]
@@ -74,8 +19,55 @@ namespace Spk.Common.Tests.Helpers.Collections
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                ((List<string>)null).RemoveWhere(x => x != null);
+                ((List<string>)null).RemoveWhere(x => true);
             });
+        }
+
+        [Fact]
+        public void RemoveWhere_ShouldNotRemoveAnyItems_WhenPredicateIsFalse()
+        {
+            // Act
+            var result = _data.RemoveWhere(x => x == "orange");
+
+            // Assert
+            Assert.Equal(_data.Count, result.Count);
+            Assert.DoesNotContain("orange", _data);
+        }
+
+        [Fact]
+        public void RemoveWhere_ShouldRemoveAllElementsThatMatchesThePredicate()
+        {
+            // Act
+            var result = _data.RemoveWhere(x => x == "fraise" || x == "banane");
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.DoesNotContain("fraise", _data);
+            Assert.DoesNotContain("banane", _data);
+        }
+
+        [Fact]
+        public void RemoveWhere_ShouldRemoveOneElement_WhenPredicateMatchesOneElement()
+        {
+            // Act
+            var result = _data.RemoveWhere(x => x == "fraise");
+
+            // Assert
+            Assert.Equal(3, result.Count);
+            Assert.DoesNotContain("fraise", _data);
+        }
+
+        [Fact]
+        public void RemoveWhere_ShouldReturn_WhenSourceIsEmpty()
+        {
+            // Arrange
+            var data = new List<string>();
+
+            // Act
+            var result = data.RemoveWhere(x => x == "fraise" || x == "banane");
+
+            // Assert
+            Assert.Equal(0, result.Count);
         }
     }
 }


### PR DESCRIPTION
This refactor include speed and memory allocations improvements:

``` ini

BenchmarkDotNet=v0.10.10, OS=Windows 10.0.18362
Processor=Intel Core i7-10710U CPU 1.10GHz, ProcessorCount=12
.NET Core SDK=3.1.101
  [Host]     : .NET Core 2.1.13 (Framework 4.6.28008.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.13 (Framework 4.6.28008.01), 64bit RyuJIT


```
|                Method |     Mean |    Error |   StdDev | Allocated |
|---------------------- |---------:|---------:|---------:|----------:|
|   RemoveWhere_Initial | 85.16 us | 1.292 us | 1.209 us |     152 B |
| RemoveWhere_Optimized | 76.77 us | 1.210 us | 1.073 us |      40 B |

Bonus point: we use these classes during the hiring process, there will be more "meat on the bone".